### PR TITLE
Enable linting of .jsx files

### DIFF
--- a/jscs/extension.ts
+++ b/jscs/extension.ts
@@ -20,7 +20,7 @@ export function activate(context: ExtensionContext) {
 	};
 
 	let clientOptions: LanguageClientOptions = {
-		documentSelector: ['javascript'],
+		documentSelector: ['javascript', 'javascriptreact'],
 		synchronize: {
 			configurationSection: 'jscs',
 			fileEvents: workspace.createFileSystemWatcher('**/.jscsrc')


### PR DESCRIPTION
adding `javascriptreact` to the document selector.
Fixes #5
