### PR TITLE
Add JSON schema support for .jscsrc file

### DIFF
--- a/jscs/package.json
+++ b/jscs/package.json
@@ -55,10 +55,14 @@
 					"default": "",
 					"description": "A JSCS configuration object"
 				}
-
-
 			}
-		}
+		},
+		"jsonValidation": [
+			{
+				"fileMatch": ".jscsrc",
+				"url": "http://json.schemastore.org/jscsrc"
+			}
+		]        
 	},
 	"scripts": {
 		"vscode:prepublish": "cd ../jscs-server && npm run compile && cd ../jscs && node ./node_modules/vscode/bin/compile",


### PR DESCRIPTION
Adds JSON schema support for the .jscsrc configuration file. This PR address [this issue](https://github.com/Microsoft/vscode-jscs/issues/2).
