### PR TITLE
Update server launch paths and client dependencies

### DIFF
--- a/jscs-server/.vscode/launch.json
+++ b/jscs-server/.vscode/launch.json
@@ -11,7 +11,7 @@
 			// Port to attach to.
 			"port": 6004,
 			"sourceMaps": true,
-			"outDir": "../jscs/server"
+			"outDir": "${workspaceRoot}/../jscs/server"
 		}
 	]
 }

--- a/jscs/package.json
+++ b/jscs/package.json
@@ -68,7 +68,8 @@
 		"compile": "node ./node_modules/vscode/bin/compile -watch -p ./"
 	},
 	"devDependencies": {
-		"vscode": "0.10.x"
+		"vscode": "0.10.x",
+		"typescript": "^1.6.2"
 	},
 	"dependencies": {
 		"vscode-languageclient": "^1.1.0"


### PR DESCRIPTION
Per Issue #11 
The launch.json for the server wasn't working in current VSCode.  VSCode complaining that it no longer accepts relative paths.
The client package.json was missing the TypeScript dev dependency.  Wasn't compiling on F5 without it.
