### PR TITLE
fix default value of jscs.configuration setting

### DIFF
--- a/jscs/package.json
+++ b/jscs/package.json
@@ -51,7 +51,7 @@
 				},
 				"jscs.configuration": {
 					"type": "object",
-					"default": "",
+					"default": {},
 					"description": "A JSCS configuration object"
 				}
 			}


### PR DESCRIPTION
Change default value of jscs.configuration from “” to {}.
Item jscs.configuration is type “object” not type “string”
